### PR TITLE
Prompt drive in local and repository folders

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,21 @@
         }
       ]
     },
+    "configuration": {
+      "title": "Prompt Drive",
+      "properties": {
+        "promptDrive.enableUserPromptDrive": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable user Prompt Drive ($HOME/.promptDrive)"
+        },
+        "promptDrive.useRepositoryPromptDrive": {
+          "type": "boolean",
+          "default": true,
+          "description": "Use repository Prompt Drive if present"
+        }
+      }
+    },
     "commands": [
       {
         "command": "promptDrive.sendToCopilot",

--- a/src/promptDriveProvider.ts
+++ b/src/promptDriveProvider.ts
@@ -1,12 +1,14 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
+import { PromptDriveSettings } from './settings';
 
 export class PromptDriveItem extends vscode.TreeItem {
     constructor(
         public readonly resourceUri: vscode.Uri,
         public readonly isDirectory: boolean,
-        public readonly command?: vscode.Command
+        public readonly command?: vscode.Command,
+        public readonly customLabel?: string
     ) {
         super(
             resourceUri,
@@ -15,42 +17,61 @@ export class PromptDriveItem extends vscode.TreeItem {
                 : vscode.TreeItemCollapsibleState.None
         );
 
-        const fileName = path.basename(resourceUri.fsPath);
-        this.label = fileName;
-
-        // Set the context value for context menu filtering
-        this.contextValue = isDirectory ? 'folder' : 'prompt';
-
-        // Set the icons for files and folders
-        this.iconPath = isDirectory 
-            ? vscode.ThemeIcon.Folder
-            : vscode.ThemeIcon.File;
+        if (resourceUri) {
+            const fileName = path.basename(resourceUri.fsPath);
             
-        // Set the tooltip for prompt files
-        if (!isDirectory && fileName.endsWith('.prompt')) {
-            try {
-                const content = fs.readFileSync(resourceUri.fsPath, 'utf8');
-                // Simple summary without using LLM
-                // Take the first line or first 80 characters
-                const firstLine = content.split('\n')[0] || '';
-                this.tooltip = firstLine.length > 80 
-                    ? firstLine.substring(0, 80) + '...' 
-                    : firstLine;
-            } catch (error) {
-                this.tooltip = 'Error reading prompt file';
-            }
-        }
+            // Set custom label if provided, otherwise use filename
+            this.label = customLabel || fileName;
 
-        // Set a description for prompt files based on content
-        if (!isDirectory && fileName.endsWith('.prompt')) {
-            try {
-                const stats = fs.statSync(resourceUri.fsPath);
-                const sizekB = Math.round(stats.size / 1024 * 10) / 10;
-                this.description = `${sizekB}kB`;
-            } catch (error) {
-                this.description = '';
+            // Set the context value for context menu filtering
+            this.contextValue = isDirectory ? 'folder' : 'prompt';
+
+            // Set the icons for files and folders
+            this.iconPath = isDirectory 
+                ? vscode.ThemeIcon.Folder
+                : vscode.ThemeIcon.File;
+                
+            // Set the tooltip for prompt files
+            if (!isDirectory && fileName.endsWith('.prompt')) {
+                try {
+                    const content = fs.readFileSync(resourceUri.fsPath, 'utf8');
+                    // Simple summary without using LLM
+                    // Take the first line or first 80 characters
+                    const firstLine = content.split('\n')[0] || '';
+                    this.tooltip = firstLine.length > 80 
+                        ? firstLine.substring(0, 80) + '...' 
+                        : firstLine;
+                } catch (error) {
+                    this.tooltip = 'Error reading prompt file';
+                }
             }
+
+            // Set a description for prompt files based on content
+            if (!isDirectory && fileName.endsWith('.prompt')) {
+                try {
+                    const stats = fs.statSync(resourceUri.fsPath);
+                    const sizekB = Math.round(stats.size / 1024 * 10) / 10;
+                    this.description = `${sizekB}kB`;
+                } catch (error) {
+                    this.description = '';
+                }
+            }
+        } else {
+            // For root nodes
+            this.contextValue = 'root';
         }
+    }
+}
+
+// Define a root node type for better type checking
+export class RootNode extends PromptDriveItem {
+    constructor(
+        public readonly rootLabel: string,
+        public readonly basePath: string
+    ) {
+        super(vscode.Uri.file(basePath), true, undefined, rootLabel);
+        this.contextValue = 'root';
+        this.description = basePath;
     }
 }
 
@@ -60,7 +81,22 @@ export class PromptDriveTreeDataProvider implements vscode.TreeDataProvider<Prom
     readonly onDidChangeTreeData: vscode.Event<PromptDriveItem | undefined | null> = 
         this._onDidChangeTreeData.event;
 
-    constructor(private readonly basePath: string) {}
+    private settings: PromptDriveSettings;
+    private userBasePath: string;
+    private repoBasePath: string | null = null;
+
+    constructor(userBasePath: string, repoBasePath?: string) {
+        this.settings = PromptDriveSettings.getInstance();
+        this.userBasePath = userBasePath;
+        this.repoBasePath = repoBasePath || null;
+        
+        // Listen for settings changes
+        vscode.workspace.onDidChangeConfiguration(e => {
+            if (e.affectsConfiguration('promptDrive')) {
+                this.refresh();
+            }
+        });
+    }
 
     refresh(): void {
         this._onDidChangeTreeData.fire();
@@ -71,13 +107,28 @@ export class PromptDriveTreeDataProvider implements vscode.TreeDataProvider<Prom
     }
 
     async getChildren(element?: PromptDriveItem): Promise<PromptDriveItem[]> {
-        if (element) {
+        if (!element) {
+            // Root level - add USER and REPOSITORY nodes
+            const rootNodes: PromptDriveItem[] = [];
+            
+            if (this.settings.enableUserPromptDrive && fs.existsSync(this.userBasePath)) {
+                rootNodes.push(new RootNode('USER', this.userBasePath));
+            }
+            
+            if (this.settings.useRepositoryPromptDrive && this.repoBasePath && fs.existsSync(this.repoBasePath)) {
+                rootNodes.push(new RootNode('REPOSITORY', this.repoBasePath));
+            }
+            
+            return rootNodes;
+        } else if (element instanceof RootNode) {
+            // Children of a root node
+            return this.getPromptDriveItems(element.basePath);
+        } else if (element.isDirectory) {
             // Children of a directory
             return this.getPromptDriveItems(element.resourceUri.fsPath);
-        } else {
-            // Root elements
-            return this.getPromptDriveItems(this.basePath);
         }
+        
+        return [];
     }
 
     private async getPromptDriveItems(directoryPath: string): Promise<PromptDriveItem[]> {
@@ -86,30 +137,28 @@ export class PromptDriveTreeDataProvider implements vscode.TreeDataProvider<Prom
         }
 
         const entries = fs.readdirSync(directoryPath);
-        const items = entries.map(entry => {
+        const items: PromptDriveItem[] = [];
+        
+        for (const entry of entries) {
             const entryPath = path.join(directoryPath, entry);
             const isDirectory = fs.statSync(entryPath).isDirectory();
             const uri = vscode.Uri.file(entryPath);
-
-            // Only show files with .prompt extension
-            if (!isDirectory && !entry.endsWith('.prompt')) {
-                return null;
+            
+            // Add all directories and only .prompt files
+            if (isDirectory || entry.endsWith('.prompt')) {
+                items.push(new PromptDriveItem(uri, isDirectory));
             }
+        }
 
-            return new PromptDriveItem(uri, isDirectory);
+        // Sort: directories first, then files
+        return items.sort((a, b) => {
+            if (a.isDirectory && !b.isDirectory) {
+                return -1;
+            }
+            if (!a.isDirectory && b.isDirectory) {
+                return 1;
+            }
+            return a.label!.localeCompare(b.label!);
         });
-
-        // Filter out null values and sort: directories first, then files
-        return items
-            .filter((item): item is PromptDriveItem => item !== null)
-            .sort((a, b) => {
-                if (a.isDirectory && !b.isDirectory) {
-                    return -1;
-                }
-                if (!a.isDirectory && b.isDirectory) {
-                    return 1;
-                }
-                return a.label!.localeCompare(b.label!);
-            });
     }
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,0 +1,55 @@
+import * as vscode from 'vscode';
+
+export class PromptDriveSettings {
+    private static _instance: PromptDriveSettings;
+
+    private _enableUserPromptDrive: boolean;
+    private _useRepositoryPromptDrive: boolean;
+
+    private constructor() {
+        // Initialize with default values from configuration
+        const config = vscode.workspace.getConfiguration('promptDrive');
+        this._enableUserPromptDrive = config.get<boolean>('enableUserPromptDrive', true);
+        this._useRepositoryPromptDrive = config.get<boolean>('useRepositoryPromptDrive', true);
+
+        // Listen for configuration changes
+        vscode.workspace.onDidChangeConfiguration(e => {
+            if (e.affectsConfiguration('promptDrive')) {
+                this.updateSettings();
+            }
+        });
+    }
+
+    /**
+     * Get the singleton instance of PromptDriveSettings
+     */
+    public static getInstance(): PromptDriveSettings {
+        if (!PromptDriveSettings._instance) {
+            PromptDriveSettings._instance = new PromptDriveSettings();
+        }
+        return PromptDriveSettings._instance;
+    }
+
+    /**
+     * Update settings from VS Code configuration
+     */
+    private updateSettings(): void {
+        const config = vscode.workspace.getConfiguration('promptDrive');
+        this._enableUserPromptDrive = config.get<boolean>('enableUserPromptDrive', true);
+        this._useRepositoryPromptDrive = config.get<boolean>('useRepositoryPromptDrive', true);
+    }
+
+    /**
+     * Check if user prompt drive is enabled
+     */
+    public get enableUserPromptDrive(): boolean {
+        return this._enableUserPromptDrive;
+    }
+
+    /**
+     * Check if repository prompt drive should be used
+     */
+    public get useRepositoryPromptDrive(): boolean {
+        return this._useRepositoryPromptDrive;
+    }
+}


### PR DESCRIPTION
Add a settings page that allows users to toggle local and repository prompt drive folders. Update tree view to show from both locations.